### PR TITLE
Ability to send email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ DynectEmail.remove_sender("myemail@example.com")
 
 # Remove account
 DynectEmail.remove_account("myemail@example.com")
+
+# Send an email
+# Note: to send to multiple addresses pass an array i.e., ["recipient1@example.com, "recipient2@example.com"]
+# Additionally, at lesat one of either bodytext or bodyhtml must be set.
+DynectEmail.send({:to => "recipient@example.com", :from => "sender@example.com", :subject => "Email Subject", :bodytext => "Hello", :bodyhtml => "<b>Hello</b>"}, "12345")
 ```
 
 Check out the [API docs](https://dynectemail.tenderapp.com/help/kb/api/introduction-to-dynect-email-deliverys-api) for more information on what parameters are available.

--- a/lib/dynect_email.rb
+++ b/lib/dynect_email.rb
@@ -40,7 +40,7 @@ module DynectEmail
     data = response['response']['data']
     # Dynect will still return a message of OK but a data status code of 4xx or 5xx
     raise DynectEmail::Error, "#{message}: #{data}" if data.is_a?(String) && (data.start_with?("4") || data.start_with?("5"))
-    raise DynectEmail::Error, message unless message == 'OK'
+    raise DynectEmail::Error, "#{message}: #{data}" unless message == 'OK'
     response['response']['data']
   end
 

--- a/lib/dynect_email.rb
+++ b/lib/dynect_email.rb
@@ -38,8 +38,8 @@ module DynectEmail
   def self.handle_response(response)
     message = response['response']['message']
     data = response['response']['data']
-    raise DynectEmail::Error, message unless message == 'OK'
     raise DynectEmail::Error, data if data.is_a?(String) && (data.start_with?("4") || data.start_with?("5"))
+    raise DynectEmail::Error, message unless message == 'OK'
     response['response']['data']
   end
 

--- a/lib/dynect_email.rb
+++ b/lib/dynect_email.rb
@@ -25,6 +25,10 @@ module DynectEmail
     post_data("/accounts/delete", :username => username)
   end
 
+  def self.send(params, apikey=nil)
+    post_data("/send", params, apikey)
+  end
+
   # {:xheader1 => "X-header", xheader2 => ....}
   def self.set_headers(headers, apikey=nil)
     post_data("/accounts/xheaders", headers, apikey)
@@ -33,7 +37,9 @@ module DynectEmail
   private
   def self.handle_response(response)
     message = response['response']['message']
+    data = response['response']['data']
     raise DynectEmail::Error, message unless message == 'OK'
+    raise DynectEmail::Error, data if data.is_a?(String) && (data.start_with?("4") || data.start_with?("5"))
     response['response']['data']
   end
 

--- a/lib/dynect_email.rb
+++ b/lib/dynect_email.rb
@@ -38,7 +38,8 @@ module DynectEmail
   def self.handle_response(response)
     message = response['response']['message']
     data = response['response']['data']
-    raise DynectEmail::Error, data if data.is_a?(String) && (data.start_with?("4") || data.start_with?("5"))
+    # Dynect will still return a message of OK but a data status code of 4xx or 5xx
+    raise DynectEmail::Error, "#{message}: #{data}" if data.is_a?(String) && (data.start_with?("4") || data.start_with?("5"))
     raise DynectEmail::Error, message unless message == 'OK'
     response['response']['data']
   end

--- a/test/dynect_email_test.rb
+++ b/test/dynect_email_test.rb
@@ -164,7 +164,7 @@ class DynectEmailTest < Test::Unit::TestCase
       result = DynectEmail.send({:to => "test@example.com"}, "12345")
     end
 
-    assert_equal "503 5.5.1 Error: need MAIL command", error.message
+    assert_equal "OK: 503 5.5.1 Error: need MAIL command", error.message
   end
 
 

--- a/test/fixtures/bad_send.json
+++ b/test/fixtures/bad_send.json
@@ -1,0 +1,1 @@
+{"response":{"status":200,"message":"OK","data":"503 5.5.1 Error: need MAIL command"}}


### PR DESCRIPTION
I noticed that the gem didn't have a method to call /send to actually send email through the API.  While most people likely use DynECT via the SMTP relay, doing it programmatically allows you to minimize your server overhead because you don't have to run postfix / sendmail and can send mail directly from Ruby.

To that end I added a method for sending emails, being mindful of the current coding conventions.
